### PR TITLE
Removing Note model import

### DIFF
--- a/oscar_support/dashboard/views.py
+++ b/oscar_support/dashboard/views.py
@@ -6,7 +6,6 @@ from django.core.urlresolvers import reverse
 from . import forms
 from .. import utils
 
-Note = get_model('oscar_support', 'Note')
 Ticket = get_model('oscar_support', 'Ticket')
 Message = get_model('oscar_support', 'Message')
 TicketStatus = get_model('oscar_support', 'TicketStatus')


### PR DESCRIPTION
oscar_support.Note doesn't exists so the app doesn't work with this orginal line:
Note = get_model('oscar_support', 'Note')
and Note model is unnecessary anyway.
